### PR TITLE
Enable drag & drop modules and multi-cassette setup

### DIFF
--- a/src/components/design-lab/construct-layout.tsx
+++ b/src/components/design-lab/construct-layout.tsx
@@ -2,7 +2,7 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { ModuleButton } from "@/components/ui/module-button"
 import { Trash2, RotateCcw, Shuffle, ArrowRight } from "lucide-react"
-import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd"
+import { Droppable, Draggable } from "@hello-pangea/dnd"
 
 interface Module {
   id: string
@@ -14,17 +14,15 @@ interface Module {
 interface ConstructLayoutProps {
   constructModules: Module[]
   onModuleRemove: (moduleId: string) => void
-  onModuleReorder: (result: any) => void
   onRandomize: () => void
   onReset: () => void
 }
 
-export const ConstructLayout = ({ 
-  constructModules, 
-  onModuleRemove, 
-  onModuleReorder,
+export const ConstructLayout = ({
+  constructModules,
+  onModuleRemove,
   onRandomize,
-  onReset 
+  onReset
 }: ConstructLayoutProps) => {
   return (
     <Card className="p-6">
@@ -49,49 +47,47 @@ export const ConstructLayout = ({
             <p className="text-sm mt-1">Maximum 5 perturbations</p>
           </div>
         ) : (
-          <DragDropContext onDragEnd={onModuleReorder}>
-            <Droppable droppableId="construct" direction="horizontal">
-              {(provided) => (
-                <div
-                  {...provided.droppableProps}
-                  ref={provided.innerRef}
-                  className="flex items-center gap-3 flex-wrap"
-                >
-                  {constructModules.map((module, index) => (
-                    <div key={module.id} className="flex items-center gap-2">
-                      <Draggable draggableId={module.id} index={index}>
-                        {(provided, snapshot) => (
-                          <div
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            {...provided.dragHandleProps}
-                            className={`relative group ${snapshot.isDragging ? 'z-10' : ''}`}
+          <Droppable droppableId="construct" direction="horizontal">
+            {(provided) => (
+              <div
+                {...provided.droppableProps}
+                ref={provided.innerRef}
+                className="flex items-center gap-3 flex-wrap"
+              >
+                {constructModules.map((module, index) => (
+                  <div key={module.id} className="flex items-center gap-2">
+                    <Draggable draggableId={module.id} index={index}>
+                      {(provided, snapshot) => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          className={`relative group ${snapshot.isDragging ? 'z-10' : ''}`}
+                        >
+                          <ModuleButton
+                            moduleType={module.type}
+                            className="cursor-move"
                           >
-                            <ModuleButton
-                              moduleType={module.type}
-                              className="cursor-move"
-                            >
-                              {module.name}
-                            </ModuleButton>
-                            <button
-                              onClick={() => onModuleRemove(module.id)}
-                              className="absolute -top-2 -right-2 bg-destructive text-destructive-foreground rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </button>
-                          </div>
-                        )}
-                      </Draggable>
-                      {index < constructModules.length - 1 && (
-                        <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                            {module.name}
+                          </ModuleButton>
+                          <button
+                            onClick={() => onModuleRemove(module.id)}
+                            className="absolute -top-2 -right-2 bg-destructive text-destructive-foreground rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        </div>
                       )}
-                    </div>
-                  ))}
-                  {provided.placeholder}
-                </div>
-              )}
-            </Droppable>
-          </DragDropContext>
+                    </Draggable>
+                    {index < constructModules.length - 1 && (
+                      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </div>
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
         )}
       </div>
 

--- a/src/components/design-lab/module-selector.tsx
+++ b/src/components/design-lab/module-selector.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { ModuleButton } from "@/components/ui/module-button"
 import { Search, Plus } from "lucide-react"
+import { Droppable, Draggable } from "@hello-pangea/dnd"
 
 interface Module {
   id: string
@@ -18,7 +19,7 @@ interface ModuleSelectorProps {
   onModuleDeselect: (moduleId: string) => void
 }
 
-const predefinedModules: Module[] = [
+export const predefinedModules: Module[] = [
   { id: "BATF", name: "BATF", type: "overexpression" },
   { id: "IRF4", name: "IRF4", type: "overexpression" },
   { id: "c-Jun", name: "c-Jun", type: "overexpression" },
@@ -81,18 +82,37 @@ export const ModuleSelector = ({ selectedModules, onModuleSelect, onModuleDesele
         Sorted by NCBI GeneBank
       </p>
 
-      <div className="flex flex-wrap gap-2">
-        {filteredModules.map((module) => (
-          <ModuleButton
-            key={module.id}
-            moduleType={module.type}
-            isSelected={isSelected(module.id)}
-            onClick={() => handleModuleClick(module)}
+      <Droppable droppableId="available-modules" direction="horizontal">
+        {(provided) => (
+          <div
+            className="flex flex-wrap gap-2"
+            ref={provided.innerRef}
+            {...provided.droppableProps}
           >
-            {module.name}
-          </ModuleButton>
-        ))}
-      </div>
+            {filteredModules.map((module, index) => (
+              <Draggable key={module.id} draggableId={module.id} index={index}>
+                {(dragProvided) => (
+                  <div
+                    ref={dragProvided.innerRef}
+                    {...dragProvided.draggableProps}
+                    {...dragProvided.dragHandleProps}
+                    className="cursor-move"
+                  >
+                    <ModuleButton
+                      moduleType={module.type}
+                      isSelected={isSelected(module.id)}
+                      onClick={() => handleModuleClick(module)}
+                    >
+                      {module.name}
+                    </ModuleButton>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
     </Card>
   )
 }

--- a/src/components/design-lab/multi-cassette-dialog.tsx
+++ b/src/components/design-lab/multi-cassette-dialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+interface MultiCassetteDialogProps {
+  open: boolean
+  cassetteCount: number
+  modulesPerCassette: number
+  setCassetteCount: (n: number) => void
+  setModulesPerCassette: (n: number) => void
+  onClose: () => void
+}
+
+export const MultiCassetteDialog = ({
+  open,
+  cassetteCount,
+  modulesPerCassette,
+  setCassetteCount,
+  setModulesPerCassette,
+  onClose
+}: MultiCassetteDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Multi-Cassette Setup</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="block mb-1 text-sm font-medium">Number of Cassettes</label>
+            <Input
+              type="number"
+              min={1}
+              value={cassetteCount}
+              onChange={(e) => setCassetteCount(parseInt(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm font-medium">Perturbations per Cassette</label>
+            <Input
+              type="number"
+              min={1}
+              value={modulesPerCassette}
+              onChange={(e) => setModulesPerCassette(parseInt(e.target.value))}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -102,5 +103,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add draggable module selector and export predefined modules
- update construct layout to rely on shared `DragDropContext`
- prompt for cassette details when switching to multi mode
- handle drag-and-drop events in design lab page
- fix lint errors and Tailwind plugin import

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6882bd4fada48332b840040bd64e55be